### PR TITLE
Release v1.0.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Latest Version](https://img.shields.io/clojars/v/com.github.pmonks/lice-comb)](https://clojars.org/com.github.pmonks/lice-comb/) [![Open Issues](https://img.shields.io/github/issues/pmonks/lice-comb.svg)](https://github.com/pmonks/lice-comb/issues) [![License](https://img.shields.io/github/license/pmonks/lice-comb.svg)](https://github.com/pmonks/lice-comb/blob/main/LICENSE)
 
-<img alt="lice-comb logo: a fine-toothed metal comb for removing headlice emblazoned with the OSI keyhole logo" align="right" width="50%" src="https://raw.githubusercontent.com/pmonks/lice-comb/main/lice-comb-logo.png">
+<img alt="lice-comb logo: a fine-toothed metal comb for removing headlice emblazoned with the OSI keyhole logo" align="right" width="25%" src="https://raw.githubusercontent.com/pmonks/lice-comb/main/lice-comb-logo.png">
 
 # lice-comb
 


### PR DESCRIPTION
com.github.pmonks/lice-comb release v1.0.22. See commit log for details of what's included in this release.